### PR TITLE
Remove `camunda-modeler-webpack-plugin` and bundle as ESM

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
     '@babel/preset-env',
-    [ '@babel/preset-react', { runtime: 'automatic' } ],
+    [ '@babel/preset-react', { runtime: 'automatic' } ]
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@testing-library/react": "^16.3.0",
         "babel-loader": "^10.0.0",
         "camunda-bpmn-js": "^5.10.0",
-        "camunda-modeler-webpack-plugin": "^0.2.0",
         "chai": "^4.5.0",
         "css-loader": "^7.1.2",
         "eslint": "^9.31.0",
@@ -4825,70 +4824,6 @@
       "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
       "license": "MIT"
     },
-    "node_modules/camunda-modeler-plugin-helpers": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/camunda-modeler-plugin-helpers/-/camunda-modeler-plugin-helpers-6.0.0.tgz",
-      "integrity": "sha512-8+BSkQvCjCzUfig1bJC/LnuuedZsD6iCsAGlAvtjjUmNm/7t598MSOVJaPrv1gBPjo8Szedym3zMmm6nys8jkw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/camunda-modeler-webpack-plugin": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/camunda-modeler-webpack-plugin/-/camunda-modeler-webpack-plugin-0.2.0.tgz",
-      "integrity": "sha512-EuAFo2LfTu/XpnUuilZbfYjHCwkdy/2xl0Yt2WBrvokGpVnNEicFIsqQrORxIXePIpnI3GnBNn9aE5t5+7LiEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.16.5",
-        "@babel/preset-react": "^7.16.7",
-        "babel-loader": "^8.2.3"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0",
-        "camunda-modeler-plugin-helpers": ">=5.0.0",
-        "webpack": ">= 5.0.0"
-      }
-    },
-    "node_modules/camunda-modeler-webpack-plugin/node_modules/babel-loader": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz",
-      "integrity": "sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-cache-dir": "^3.3.1",
-        "loader-utils": "^2.0.4",
-        "make-dir": "^3.1.0",
-        "schema-utils": "^2.6.5"
-      },
-      "engines": {
-        "node": ">= 8.9"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "webpack": ">=2"
-      }
-    },
-    "node_modules/camunda-modeler-webpack-plugin/node_modules/schema-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.5",
-        "ajv": "^6.12.4",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001727",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
@@ -5170,13 +5105,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/component-event": {
       "version": "0.2.1",
@@ -7143,24 +7071,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-up": {
@@ -9188,22 +9098,6 @@
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@testing-library/react": "^16.3.0",
     "babel-loader": "^10.0.0",
     "camunda-bpmn-js": "^5.10.0",
-    "camunda-modeler-webpack-plugin": "^0.2.0",
     "chai": "^4.5.0",
     "css-loader": "^7.1.2",
     "eslint": "^9.31.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-const CamundaModelerWebpackPlugin = require('camunda-modeler-webpack-plugin');
-
 module.exports = {
   mode: 'production',
   entry: './lib/index.jsx',
@@ -7,20 +5,31 @@ module.exports = {
   output: {
     filename: 'index.js',
     library: {
-      type: 'umd',
-      export: 'default',
+      type: 'module',
+      export: 'default'
     },
-    globalObject: 'this',
     clean: true
+  },
+  experiments: {
+    outputModule: true
+  },
+  externals: {
+    react: 'react',
+    '@carbon/react': '@carbon/react',
+    '@carbon/icons-react': '@carbon/icons-react'
   },
   resolve: {
     extensions: [ '.js', '.jsx' ]
   },
-  plugins: [
-    new CamundaModelerWebpackPlugin(),
-  ],
   module: {
     rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader'
+        }
+      },
       {
         test: /\.scss$/,
         use: [
@@ -35,7 +44,7 @@ module.exports = {
           'style-loader',
           'css-loader'
         ]
-      },
+      }
     ]
   },
 };

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -11,7 +11,7 @@ module.exports = {
   devtool: 'eval',
   devServer: {
     static: path.join(__dirname, 'demo'),
-    open: true,
+    open: true
   },
   module: {
     rules: [
@@ -19,14 +19,8 @@ module.exports = {
         test: /\.jsx?$/,
         exclude: /node_modules/,
         use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              '@babel/preset-env',
-              '@babel/preset-react',
-            ],
-          },
-        },
+          loader: 'babel-loader'
+        }
       },
       {
         test: /\.scss$/,
@@ -45,16 +39,16 @@ module.exports = {
       },
       {
         test: /\.xml$/i,
-        use: 'raw-loader',
-      },
+        use: 'raw-loader'
+      }
     ]
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: './demo/index.html',
-    }),
+      template: './demo/index.html'
+    })
   ],
   resolve: {
-    extensions: [ '.js', '.jsx' ],
+    extensions: [ '.js', '.jsx' ]
   },
 };


### PR DESCRIPTION
### Proposed Changes

* remove `camunda-modeler-webpack-plugin` as this is not a use case
* bundle as ESM with `react`, `@carbon/react` and `@carbon/icons` as externals

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
