### PR TITLE
Input editor fix

### DIFF
--- a/lib/components/Input/Input.jsx
+++ b/lib/components/Input/Input.jsx
@@ -7,7 +7,6 @@ import InputEditor from './InputEditor';
 
 export default function Input({
   allOutputs,
-  element,
   input,
   onErrorChange,
   onResetInput,
@@ -38,7 +37,6 @@ export default function Input({
       </div>
       {input && <InputEditor
         allOutputs={ allOutputs }
-        element={ element }
         value={ input }
         onChange={ onSetInput }
         onErrorChange={ onErrorChange }

--- a/lib/components/Input/InputEditor.jsx
+++ b/lib/components/Input/InputEditor.jsx
@@ -28,7 +28,6 @@ const DEFAULT_ALL_OUTPUTS = {},
 
 export default function InputEditor({
   allOutputs = DEFAULT_ALL_OUTPUTS,
-  element,
   value,
   onChange,
   onErrorChange,
@@ -135,7 +134,7 @@ export default function InputEditor({
     return () => {
       view.destroy();
     };
-  }, []);
+  }, [ onChange ]);
 
   useEffect(() => {
     if (!editorView) return;

--- a/lib/components/TaskTesting/TaskTesting.js
+++ b/lib/components/TaskTesting/TaskTesting.js
@@ -317,7 +317,6 @@ export default function TaskTesting({
         </div>
         <Input
           allOutputs={ allOutputs }
-          element={ element }
           input={ input }
           onErrorChange={ setInputError }
           onResetInput={ handleResetInput }


### PR DESCRIPTION
### Changes
- Make sure InputEditor re-renders when `onChange` prop changes (when `element` changes in parent)
- Get rid of InputEditor flickering when switching elements