### PR TITLE
chore: better typing for TaskExecution

### DIFF
--- a/lib/TaskExecution.js
+++ b/lib/TaskExecution.js
@@ -8,19 +8,33 @@
  * except in compliance with the MIT License.
  */
 
+/**
+ * @import {
+ *   TaskExecutionApi,
+ *   TaskExecutionResult,
+ *   TaskExecutionError,
+ *   TaskExecutionStatus
+ * } from './types';
+ */
+
+/**
+ * @import {
+ *   CreateProcessInstanceResponse,
+ *   DeployResourceResponse
+ * } from '@camunda8/sdk/dist/c8/lib/C8Dto';
+ */
+
 import EventEmitter from 'events';
 
 export const INTERVAL_MS = 1000;
 
-/**
- * @import { TaskExecutionApi, TaskExecutionResult, TaskExecutionError, TaskExecutionStatus } from './types';
- */
 
 /**
  * Emits:
  * - `taskExecution.status.changed` with one of {@link TaskExecutionStatus}
  * - `taskExecution.finished` with {@link TaskExecutionResult}
  * - `taskExecution.error` with {@link TaskExecutionError}
+ * - `taskExecution.interrupted` when execution is interrupted by switching focus
  */
 export default class TaskExecution extends EventEmitter {
 
@@ -232,15 +246,11 @@ export default class TaskExecution extends EventEmitter {
 /**
  * Get the process ID from the deployment response.
  *
- * @param {import('./types').DeploymentResponse} [response]
+ * @param {DeployResourceResponse} response
  *
  * @returns {string|null} The process ID or null if not found.
  */
 function getProcessId(response) {
-  if (!response) {
-    return null;
-  }
-
   const { processes = [] } = response;
 
   for (const process of processes) {
@@ -255,15 +265,11 @@ function getProcessId(response) {
 /**
  * Get the process instance key from the response.
  *
- * @param {import('./types').StartInstanceResponse} [response]
+ * @param {CreateProcessInstanceResponse} response
  *
  * @returns {string|null} The process instance key or null if not found.
  */
 function getProcessInstanceKey(response) {
-  if (!response) {
-    return null;
-  }
-
   const { processInstanceKey } = response;
 
   return processInstanceKey || null;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -38,46 +38,22 @@ export type Variable = {
 
 export type Variables = Variable[];
 
-export type DeploymentResponse = DeployResourceResponse;
-
-export type DeploymentResult = {
-  success: boolean;
-  response?: DeploymentResponse;
-  error?: string;
-}
-
-export type StartInstanceResponse = CreateProcessInstanceResponse;
-
-export type StartInstanceResult = {
-  success: boolean;
-  response?: StartInstanceResponse;
-  error?: string;
-}
-
-export type GetProcessInstanceResult = {
-  success: boolean;
-  response?: SearchProcessInstanceResponse;
-  error?: string;
-}
-
-export type GetProcessInstanceVariablesResult = {
-  success: boolean;
-  response?: SearchVariablesResponse;
-  error?: string;
-}
-
-export type GetProcessInstanceIncidentResult = {
-  success: boolean;
-  response?: SearchIncidentsResponse;
-  error?: string;
-}
+export type ApiResponse<T> =
+  | {
+      success: true;
+      response: T;
+    }
+  | {
+      success: false;
+      error: string;
+    }
 
 export type TaskExecutionApi = {
-  deploy: () => Promise<DeploymentResult>;
-  startInstance: (processId: string, elementId: string, variables: { [key: string]: any }) => Promise<StartInstanceResult>;
-  getProcessInstance: (processInstanceKey: string) => Promise<GetProcessInstanceResult>;
-  getProcessInstanceVariables: (processInstanceKey: string) => Promise<GetProcessInstanceVariablesResult>;
-  getProcessInstanceIncident: (processInstanceKey: string) => Promise<GetProcessInstanceIncidentResult>;
+  deploy: () => Promise<ApiResponse<DeployResourceResponse>>;
+  startInstance: (processId: string, elementId: string, variables: { [key: string]: any }) => Promise<ApiResponse<CreateProcessInstanceResponse>>;
+  getProcessInstance: (processInstanceKey: string) => Promise<ApiResponse<SearchProcessInstanceResponse>>;
+  getProcessInstanceVariables: (processInstanceKey: string) => Promise<ApiResponse<SearchVariablesResponse>>;
+  getProcessInstanceIncident: (processInstanceKey: string) => Promise<ApiResponse<SearchIncidentsResponse>>;
 };
 
 export type TaskExecutionStatus =


### PR DESCRIPTION
### Changes

Simplify types for TaskExecution.

This ensures there is always a response on success and always an error on failure.