### PR TITLE
chore: change Webpack mode to `production`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   entry: './lib/index.jsx',
   devtool: 'source-map',
   output: {


### PR DESCRIPTION
### Changes

Change Webpack mode to `production`.

Possibly fix to https://github.com/camunda/camunda-modeler/issues/5315, cf. similar issue https://github.com/diegomura/react-pdf/issues/565#issuecomment-486547184