### PR TITLE
fix: react to `operateBaseUrl` change

### DIFF
--- a/lib/components/TaskTesting/TaskTesting.js
+++ b/lib/components/TaskTesting/TaskTesting.js
@@ -229,7 +229,7 @@ export default function TaskTesting({
         taskExecutionRef.current.off('taskExecution.interrupted', handleInterrupted);
       }
     };
-  }, [ element ]);
+  }, [ element, operateBaseUrl ]);
 
   useEffect(() => {
     if (config && elementConfigRef.current) {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5290

### Changes

Make sure we recreate our status handling functions when Operate URL changes from the modeler.