### PR TITLE
fix: cancel current execution if `injector` changes

### DIFF
--- a/lib/components/TaskTesting/TaskTesting.js
+++ b/lib/components/TaskTesting/TaskTesting.js
@@ -109,6 +109,10 @@ export default function TaskTesting({
 
     const taskExecution = new TaskExecution(injector, api);
     taskExecutionRef.current = taskExecution;
+
+    return () => {
+      taskExecutionRef.current?.cancelTaskExecution();
+    };
   }, [ injector ]);
 
   // Get input variables for the selected element


### PR DESCRIPTION
### Changes

Explicitly cancel task execution of `injector` changes. This prevents weird behavior (stuck at some state) of task testing when switching between files in Desktop Modeler.