### PR TITLE
fix: separate process and local variables

### DIFF
--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -50,6 +50,10 @@ function App() {
             r: 18,
             s: 19,
             t: 20
+          }, null, 2),
+          'ServiceTask_2': JSON.stringify({
+            foo: 1,
+            bar: 'baz'
           }, null, 2)
         },
         output: {
@@ -213,6 +217,11 @@ function App() {
       .then(response => response.json());
   };
 
+  const getProcessInstanceElementInstances = async (processInstanceKey) => {
+    return fetch(`/api/getProcessInstanceElementInstances/${processInstanceKey}`)
+      .then(response => response.json());
+  };
+
   const getProcessInstanceIncident = async (processInstanceKey) => {
     return fetch(`/api/getProcessInstanceIncident/${processInstanceKey}`)
       .then(response => response.json());
@@ -246,6 +255,7 @@ function App() {
             startInstance,
             getProcessInstance,
             getProcessInstanceVariables,
+            getProcessInstanceElementInstances,
             getProcessInstanceIncident
           } }
           config={ config }

--- a/demo/diagram.bpmn
+++ b/demo/diagram.bpmn
@@ -21,6 +21,7 @@
           <zeebe:input source="={ foo: 1 }" target="contextInput" />
           <zeebe:input source="=foo + bar + baz" target="complexInput" />
           <zeebe:output source="=fooOutput" target="foo" />
+          <zeebe:output source="=true" target="baz" />
         </zeebe:ioMapping>
         <zeebe:script expression="=fooInput + 2" resultVariable="fooOutput" />
       </bpmn:extensionElements>

--- a/demo/server.mjs
+++ b/demo/server.mjs
@@ -143,6 +143,28 @@ app.get('/api/getProcessInstanceVariables/:processInstanceKey', async (req, res)
   }
 });
 
+app.get('/api/getProcessInstanceElementInstances/:processInstanceKey', async (req, res) => {
+  try {
+    if (!camunda) {
+      return res.json({ success: false, error: 'Camunda environment not configured' });
+    }
+
+    const { processInstanceKey } = req.params;
+
+    const client = camunda.getCamundaRestClient();
+
+    const response = await client.searchElementInstances({
+      filter: {
+        processInstanceKey
+      }
+    });
+
+    res.json({ success: true, response });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
 app.get('/api/getProcessInstanceIncident/:processInstanceKey', async (req, res) => {
   try {
     if (!camunda) {

--- a/lib/TaskExecution.js
+++ b/lib/TaskExecution.js
@@ -28,6 +28,11 @@ import EventEmitter from 'events';
 
 export const INTERVAL_MS = 1000;
 
+export const SCOPES = {
+  LOCAL: 'LOCAL',
+  PROCESS: 'PROCESS'
+};
+
 
 /**
  * Emits:
@@ -185,7 +190,27 @@ export default class TaskExecution extends EventEmitter {
           return;
         }
 
-        const variables = getVariables(getProcessInstanceVariablesResult.response);
+        const getProcessInstanceElementInstancesResult = await this._api.getProcessInstanceElementInstances(processInstanceKey);
+
+        if (/** @type {TaskExecutionStatus} */ (this._status) === 'idle') {
+
+          // Execution was canceled in the meantime
+          this.cancelTaskExecution();
+          return;
+        }
+
+        if (!getProcessInstanceElementInstancesResult.success) {
+          this._emitError('Failed to get process instance element instances', getProcessInstanceElementInstancesResult.error);
+          return;
+        }
+
+        const variables = getVariables(
+          getProcessInstanceVariablesResult.response.items,
+          getProcessInstanceElementInstancesResult.response.items,
+          processInstance,
+          elementId
+        );
+
         this.emit('taskExecution.finished', {
           success: !incident,
           incident,
@@ -307,18 +332,24 @@ function hasProcessInstanceIncident(response, processInstanceKey) {
   return processInstance.hasIncident || false;
 }
 
-function getVariables(response) {
-  const { items = [] } = response;
-
+export function getVariables(getVariablesResponseItems, getElementInstancesResponseItems, processInstance, elementId) {
   const variables = {};
 
-  for (const item of items) {
-    const { name, value } = item;
+  for (const getVariablesResponseItem of getVariablesResponseItems) {
+    const { name, value } = getVariablesResponseItem;
+
+    const scope = getScope(getVariablesResponseItem, getElementInstancesResponseItems, processInstance, elementId);
 
     try {
-      variables[name] = JSON.parse(value);
+      variables[name] = {
+        value: JSON.parse(value),
+        scope
+      };
     } catch {
-      variables[name] = value;
+      variables[name] = {
+        value,
+        scope
+      };
     }
   }
 
@@ -333,4 +364,24 @@ function getIncident(response) {
   }
 
   return items[0];
+}
+
+function getScope(variable, elementInstances, processInstance, elementId) {
+  const { scopeKey } = variable;
+
+  const elementInstance = elementInstances.find(elementInstance => {
+    return elementInstance.elementInstanceKey === scopeKey && elementInstance.elementId === elementId;
+  });
+
+  if (elementInstance) {
+    return SCOPES.LOCAL;
+  }
+
+  const { processInstanceKey } = processInstance;
+
+  if (scopeKey === processInstanceKey) {
+    return SCOPES.PROCESS;
+  }
+
+  return null;
 }

--- a/lib/components/Output/Output.jsx
+++ b/lib/components/Output/Output.jsx
@@ -21,6 +21,8 @@ import {
 
 import OutputEditor from './OutputEditor';
 
+import { SCOPES } from '../../TaskExecution';
+
 export const TASK_EXECUTION_STATUS_LABEL = {
   deploying: 'Deploying...',
   'starting-instance': 'Starting instance...',
@@ -89,7 +91,7 @@ export default function Output({
       }
 
       if (output.success) {
-        return 'Process variables after execution';
+        return 'Success';
       }
     }
 
@@ -153,27 +155,22 @@ function OutputVariables({
   }
 
   if (output?.success) {
-    return <OutputEditor
-      value={ JSON.stringify(output.variables, null, 2) }
-    />;
-
-    // TODO: Introduce tabs when able to filter variables by `scopeKey`
-    // return (
-    //   <Tabs>
-    //     <TabList>
-    //       <Tab>Process variables</Tab>
-    //       <Tab>Task variables</Tab>
-    //     </TabList>
-    //     <TabPanels>
-    //       <TabPanel>
-    //         <OutputEditor value={ JSON.stringify(output.variables, null, 2) } />
-    //       </TabPanel>
-    //       <TabPanel>
-    //         <OutputEditor value={ JSON.stringify(output.variables, null, 2) } />
-    //       </TabPanel>
-    //     </TabPanels>
-    //   </Tabs>
-    // );
+    return (
+      <Tabs>
+        <TabList>
+          <Tab>Process variables</Tab>
+          <Tab>Local variables</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <OutputEditor value={ JSON.stringify(pickVariables(output.variables, SCOPES.PROCESS), null, 2) } />
+          </TabPanel>
+          <TabPanel>
+            <OutputEditor value={ JSON.stringify(pickVariables(output.variables, SCOPES.LOCAL), null, 2) } />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    );
   }
 
   if (output?.error) {
@@ -273,4 +270,22 @@ function printIncident(incident) {
  */
 function capitalize(string) {
   return string.replace(/([A-Z])/g, ' $1').replace(/^./, (match) => match.toUpperCase());
+}
+
+/**
+ * Pick variables for a given scope.
+ *
+ * @param {Object} variables
+ * @param {string} scope
+ *
+ * @returns {Object}
+ */
+function pickVariables(variables, scope) {
+  return Object.entries(variables).reduce((variables, [ name, variable ]) => {
+    if (scope === variable.scope) {
+      variables[name] = variable.value;
+    }
+
+    return variables;
+  }, {});
 }

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -3,6 +3,7 @@ import type {
   DeployResourceResponse,
   SearchProcessInstanceResponse,
   SearchVariablesResponse,
+  SearchElementInstancesResponse,
   SearchIncidentsResponse
 } from '@camunda8/sdk/dist/c8/lib/C8Dto';
 
@@ -20,6 +21,7 @@ export type ElementOutput = {
   error?: TaskExecutionEvents.Error;
   incident?: any;
   operateUrl?: string;
+  [key: string]: any;
 } | undefined;
 
 export type Config = {
@@ -53,6 +55,7 @@ export type TaskExecutionApi = {
   startInstance: (processId: string, elementId: string, variables: { [key: string]: any }) => Promise<ApiResponse<CreateProcessInstanceResponse>>;
   getProcessInstance: (processInstanceKey: string) => Promise<ApiResponse<SearchProcessInstanceResponse>>;
   getProcessInstanceVariables: (processInstanceKey: string) => Promise<ApiResponse<SearchVariablesResponse>>;
+  getProcessInstanceElementInstances: (processInstanceKey: string) => Promise<ApiResponse<SearchElementInstancesResponse>>;
   getProcessInstanceIncident: (processInstanceKey: string) => Promise<ApiResponse<SearchIncidentsResponse>>;
 };
 

--- a/test/TaskExecution.spec.js
+++ b/test/TaskExecution.spec.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import { bootstrapModeler, inject } from './util/Util';
 
-import TaskExecution, { INTERVAL_MS } from '../lib/TaskExecution';
+import TaskExecution, { getVariables, INTERVAL_MS, SCOPES } from '../lib/TaskExecution';
 
 describe('TaskExecution', function() {
 
@@ -30,6 +30,7 @@ describe('TaskExecution', function() {
       startInstance: sinon.stub().resolves({ success: false, error: 'Not implemented' }),
       getProcessInstance: sinon.stub().resolves({ success: false, error: 'Not implemented' }),
       getProcessInstanceVariables: sinon.stub().resolves({ success: false, error: 'Not implemented' }),
+      getProcessInstanceElementInstances: sinon.stub().resolves({ success: false, error: 'Not implemented' }),
       getProcessInstanceIncident: sinon.stub().resolves({ success: false, error: 'Not implemented' })
     };
 
@@ -48,6 +49,7 @@ describe('TaskExecution', function() {
     errorSpy.resetHistory();
   });
 
+
   it('should execute a task', async function() {
 
     // given
@@ -55,6 +57,7 @@ describe('TaskExecution', function() {
     api.startInstance.resolves({ success: true, response: DEFAULT_START_INSTANCE_RESPONSE });
     api.getProcessInstance.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_RESPONSE });
     api.getProcessInstanceVariables.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_VARIABLES_RESPONSE });
+    api.getProcessInstanceElementInstances.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_ELEMENT_INSTANCES_RESPONSE });
 
     // when
     taskExecution.executeTask('ServiceTask_1', { foo: 'bar' });
@@ -72,14 +75,21 @@ describe('TaskExecution', function() {
     expect(api.startInstance).to.have.been.calledOnce;
     expect(api.getProcessInstance).to.have.been.calledOnce;
     expect(api.getProcessInstanceVariables).to.have.been.calledOnce;
+    expect(api.getProcessInstanceElementInstances).to.have.been.calledOnce;
     expect(api.getProcessInstanceIncident).to.not.have.been.called;
 
     expect(finishedSpy).to.have.been.calledWithMatch({
       'incident': null,
       'success': true,
       'variables': {
-        'foo': 'bar',
-        'baz': 42
+        'foo': {
+          'value': 'bar',
+          'scope': 'PROCESS'
+        },
+        'baz': {
+          'value': 42,
+          'scope': 'PROCESS'
+        }
       }
     });
   });
@@ -93,6 +103,7 @@ describe('TaskExecution', function() {
     api.getProcessInstance.onFirstCall().resolves({ success: true, response: { items: [] } });
     api.getProcessInstance.onSecondCall().resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_RESPONSE });
     api.getProcessInstanceVariables.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_VARIABLES_RESPONSE });
+    api.getProcessInstanceElementInstances.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_ELEMENT_INSTANCES_RESPONSE });
 
     // when
     taskExecution.executeTask('ServiceTask_1', { foo: 'bar' });
@@ -106,13 +117,20 @@ describe('TaskExecution', function() {
     expect(api.startInstance).to.have.been.calledOnce;
     expect(api.getProcessInstance).to.have.been.calledTwice;
     expect(api.getProcessInstanceVariables).to.have.been.calledOnce;
+    expect(api.getProcessInstanceElementInstances).to.have.been.calledOnce;
     expect(api.getProcessInstanceIncident).to.not.have.been.called;
 
     expect(finishedSpy).to.have.been.calledWithMatch({
       'incident': null,
       'variables': {
-        'foo': 'bar',
-        'baz': 42
+        'foo': {
+          'value': 'bar',
+          'scope': 'PROCESS'
+        },
+        'baz': {
+          'value': 42,
+          'scope': 'PROCESS'
+        }
       }
     });
   });
@@ -294,6 +312,7 @@ describe('TaskExecution', function() {
       api.getProcessInstance.onFirstCall().resolves({ success: false, error: GET_PROCESS_INSTANCE_ERROR });
       api.getProcessInstance.onSecondCall().resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_RESPONSE });
       api.getProcessInstanceVariables.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_VARIABLES_RESPONSE });
+      api.getProcessInstanceElementInstances.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_ELEMENT_INSTANCES_RESPONSE });
 
       // when
       taskExecution.executeTask('ServiceTask_1', { foo: 'bar' });
@@ -307,6 +326,7 @@ describe('TaskExecution', function() {
       expect(api.startInstance).to.have.been.calledOnce;
       expect(api.getProcessInstance).to.have.been.calledTwice;
       expect(api.getProcessInstanceVariables).to.have.been.calledOnce;
+      expect(api.getProcessInstanceElementInstances).to.have.been.calledOnce;
       expect(api.getProcessInstanceIncident).to.not.have.been.called;
 
       expect(errorSpy).to.have.been.calledWithMatch({
@@ -356,6 +376,7 @@ describe('TaskExecution', function() {
         ]
       } });
       api.getProcessInstanceVariables.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_VARIABLES_RESPONSE });
+      api.getProcessInstanceElementInstances.resolves({ success: true, response: DEFAULT_GET_PROCESS_INSTANCE_ELEMENT_INSTANCES_RESPONSE });
 
       // when
       taskExecution.executeTask('ServiceTask_1', { foo: 'bar' });
@@ -369,13 +390,20 @@ describe('TaskExecution', function() {
       expect(api.startInstance).to.have.been.calledOnce;
       expect(api.getProcessInstance).to.have.been.calledOnce;
       expect(api.getProcessInstanceVariables).to.have.been.calledOnce;
+      expect(api.getProcessInstanceElementInstances).to.have.been.calledOnce;
       expect(api.getProcessInstanceIncident).to.have.been.calledOnce;
 
       expect(finishedSpy).to.have.been.calledWithMatch({
         'success': false,
         'variables': {
-          'foo': 'bar',
-          'baz': 42
+          'foo': {
+            'value': 'bar',
+            'scope': 'PROCESS'
+          },
+          'baz': {
+            'value': 42,
+            'scope': 'PROCESS'
+          }
         },
         'incident': {
           key: '2251799814592731',
@@ -492,6 +520,63 @@ describe('TaskExecution', function() {
 
   });
 
+
+  describe('#getVariables', function() {
+
+    it('should get variables with scope', function() {
+
+      // given
+      const getVariablesResponseItems = [
+        {
+          name: 'localFoo',
+          value: 'bar',
+          scopeKey: '1'
+        },
+        {
+          name: 'localBaz',
+          value: 42,
+          scopeKey: '1'
+        },
+        {
+          name: 'processFoo',
+          value: true,
+          scopeKey: '2'
+        },
+        {
+          name: 'otherLocalFoo',
+          value: 'baz',
+          scopeKey: '3'
+        }
+      ];
+
+      const getElementInstancesResponseItems = [
+        {
+          elementId: 'ServiceTask_1',
+          elementInstanceKey: '1'
+        }
+      ];
+
+      // when
+      const variables = getVariables(
+        getVariablesResponseItems,
+        getElementInstancesResponseItems,
+        {
+          processInstanceKey: '2'
+        },
+        'ServiceTask_1'
+      );
+
+      // then
+      expect(variables).to.eql({
+        localFoo: { value: 'bar', scope: SCOPES.LOCAL },
+        localBaz: { value: 42, scope: SCOPES.LOCAL },
+        processFoo: { value: true, scope: SCOPES.PROCESS },
+        otherLocalFoo: { value: 'baz', scope: null }
+      });
+    });
+
+  });
+
 });
 
 const DEFAULT_DEPLOY_RESPONSE = {
@@ -587,5 +672,30 @@ const DEFAULT_GET_PROCESS_INSTANCE_VARIABLES_RESPONSE = {
     'hasMoreTotalItems': false,
     'startCursor': 'WzIyNTE3OTk4MTM3NTU5MjNd',
     'endCursor': 'WzIyNTE3OTk4MTM3NTU5NDVd'
+  }
+};
+
+const DEFAULT_GET_PROCESS_INSTANCE_ELEMENT_INSTANCES_RESPONSE = {
+  'items': [
+    {
+      'processDefinitionId': 'Process_TaskTesting',
+      'startDate': '2025-10-16T13:08:56.455Z',
+      'endDate': '2025-10-16T13:08:56.455Z',
+      'elementId': 'ServiceTask_2',
+      'elementName': 'Inputs',
+      'type': 'SCRIPT_TASK',
+      'state': 'COMPLETED',
+      'hasIncident': false,
+      'tenantId': '<default>',
+      'elementInstanceKey': '2251799817092569',
+      'processInstanceKey': '2251799817092566',
+      'processDefinitionKey': '2251799817066246'
+    }
+  ],
+  'page': {
+    'totalItems': 1,
+    'hasMoreTotalItems': false,
+    'startCursor': 'WzIyNTE3OTk4MTcwOTI1Njld',
+    'endCursor': 'WzIyNTE3OTk4MTcwOTI1Njld'
   }
 };


### PR DESCRIPTION
Separates variables into process and local scope. We should release this as a `v1.0.0` as this is a breaking change due to the requirement of a `getProcessInstanceElementInstances` callback.

![brave_mjZg951HQv](https://github.com/user-attachments/assets/6aacb844-4136-4ffd-a7d1-b06f4f7d7c01)

Closes #12