### PR TITLE
fix: make sure last part of Operate URL is not trimmed off

### DIFF
--- a/lib/components/TaskTesting/TaskTesting.js
+++ b/lib/components/TaskTesting/TaskTesting.js
@@ -26,6 +26,7 @@ import Output from '../Output/Output';
 import TaskExecution from '../../TaskExecution';
 
 import { getName, getType } from '../../utils/element';
+import { getOperateUrl } from '../../utils/getOperateUrl';
 
 import '../../style/style.scss';
 
@@ -206,8 +207,8 @@ export default function TaskTesting({
       setTaskExecutionStatus(status);
 
       if (processInstanceKey && operateBaseUrl) {
-        const operateUrl = new URL(`processes/${processInstanceKey}`, `${operateBaseUrl}/`).toString();
-        setCurrentOperateUrl(operateUrl);
+        const url = getOperateUrl(operateBaseUrl, processInstanceKey);
+        setCurrentOperateUrl(url);
       }
 
       if (status === 'idle') {

--- a/lib/utils/getOperateUrl.js
+++ b/lib/utils/getOperateUrl.js
@@ -1,0 +1,13 @@
+/**
+ * @param {string} operateBaseUrl
+ * @param {string} processInstanceKey
+ * @returns {string}
+ */
+export function getOperateUrl(operateBaseUrl, processInstanceKey) {
+
+  const normalizedBase = operateBaseUrl.replace(/\/+$/, '');
+  const path = `processes/${processInstanceKey}`;
+
+  const url = new URL(path, `${normalizedBase}/`);
+  return url.toString();
+}

--- a/test/utils/getOperateUrl.spec.js
+++ b/test/utils/getOperateUrl.spec.js
@@ -1,0 +1,35 @@
+import { getOperateUrl } from '../../lib/utils/getOperateUrl';
+
+describe('getOperateUrl', function() {
+
+  const processInstanceKey = '12345';
+
+  it('should return the correct URL', function() {
+    const operateBaseUrl = 'http://localhost:3000';
+    const expectedUrl = 'http://localhost:3000/processes/12345';
+    expect(getOperateUrl(operateBaseUrl, processInstanceKey)).to.eql(expectedUrl);
+  });
+
+
+  it('should return the correct URL with path', function() {
+    const operateBaseUrl = 'http://camunda.com/operate';
+    const expectedUrl = 'http://camunda.com/operate/processes/12345';
+    expect(getOperateUrl(operateBaseUrl, processInstanceKey)).to.eql(expectedUrl);
+  });
+
+
+  it('should handle trailing slash in base URL', function() {
+    const operateBaseUrl = 'http://camunda.com/operate/';
+    const expectedUrl = 'http://camunda.com/operate/processes/12345';
+    expect(getOperateUrl(operateBaseUrl, processInstanceKey)).to.eql(expectedUrl);
+  });
+
+
+  it('should handle multiple trailing slashes in base URL', function() {
+    const operateBaseUrl = 'http://camunda.com/operate///';
+    const expectedUrl = 'http://camunda.com/operate/processes/12345';
+    expect(getOperateUrl(operateBaseUrl, processInstanceKey)).to.eql(expectedUrl);
+  });
+
+});
+


### PR DESCRIPTION
### Changes

If the `base` parameter of the URL constructor doesn't end with a slash, the last part of the path is treated as a file name and replaced when combining the URL.