### PR TITLE
fix: do not change selected element while it is being moved

### DIFF
--- a/lib/hooks/useSelectedElement.js
+++ b/lib/hooks/useSelectedElement.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 import {
   getBusinessObject,
@@ -25,19 +25,32 @@ export function useSelectedElement(injector) {
   /** @type {[ string|null, Function ]} */
   const [ message, setMessage ] = useState(SINGLE_TASK_SELECTION_REQUIRED_MESSAGE);
 
-  useEffect(() => {
-    const selection = injector.get('selection');
+  const eventBus = useMemo(() => injector.get('eventBus'), [ injector ]);
 
+  useEffect(() => {
+
+    // Some elements can already be selected on mount
+    const selection = injector.get('selection');
     handleSelection({ newSelection: selection.get() });
 
-    const eventBus = injector.get('eventBus');
-
     eventBus.on('selection.changed', handleSelection);
+    eventBus.on('shape.move.start', handleShapeMoveStart);
+    eventBus.on('shape.move.end', handleShapeMoveEnd);
 
     return () => {
       eventBus.off('selection.changed', handleSelection);
+      eventBus.off('shape.move.start', handleShapeMoveStart);
+      eventBus.off('shape.move.end', handleShapeMoveEnd);
     };
-  }, [ injector ]);
+  }, [ injector, eventBus ]);
+
+  const handleShapeMoveStart = () => {
+    eventBus.off('selection.changed', handleSelection);
+  };
+
+  const handleShapeMoveEnd = () => {
+    eventBus.on('selection.changed', handleSelection);
+  };
 
   const handleSelection = ({ newSelection }) => {
     const error = validateSelection(newSelection);

--- a/test/hooks/useSelectedElement.spec.js
+++ b/test/hooks/useSelectedElement.spec.js
@@ -94,4 +94,34 @@ describe('useSelectedElement', function() {
     }
   ));
 
+
+  it('should not change while an element is being moved', inject(
+    function(injector, selection, elementRegistry, move) {
+
+      // given
+      const { result } = renderHook(() => useSelectedElement(injector));
+
+      // when
+      act(() => {
+        const element = elementRegistry.get('ServiceTask_1');
+        selection.select(element);
+      });
+
+      // assume
+      let [ selectedElement, message ] = result.current;
+      expect(selectedElement).to.exist;
+      expect(message).to.be.null;
+
+      // when
+      act(() => {
+        move.start(elementRegistry.get('ServiceTask_1'), { x: 10, y: 10 });
+      });
+
+      // then
+      [ selectedElement, message ] = result.current;
+      expect(selectedElement).to.exist;
+      expect(message).to.be.null;
+    }
+  ));
+
 });


### PR DESCRIPTION
### Changes

Temporarily subscribe off `selection.changed` while an element is being moved to prevent annoying flickering of the task testing tab.

Related to https://github.com/camunda/camunda-modeler/issues/5398

![no-tt-flicker](https://github.com/user-attachments/assets/680952f3-8bd1-4286-8c88-1a9563fa3876)
