### PR TITLE
fix: make output loading animation take full width

### DIFF
--- a/lib/style/style.scss
+++ b/lib/style/style.scss
@@ -215,6 +215,10 @@
       font-weight: bold;
     }
 
+    .output__variables--skeleton {
+      max-inline-size: unset;
+    }
+
     code {
       font-size: 14px;
     }


### PR DESCRIPTION
### Changes

Unset the output skeleton's `max-inline-size` property to make it take full width even on super-duper wide screens:

Before

<img width="2881" height="489" alt="image" src="https://github.com/user-attachments/assets/5f1af593-74e4-44bc-8b43-1ec14d732143" />

After

<img width="3412" height="228" alt="image" src="https://github.com/user-attachments/assets/c0d43486-503f-407a-8dec-857f199021b5" />
