### PR TITLE
fix: do not show local task variables in the autocompletion

### DIFF
--- a/lib/ElementVariables.js
+++ b/lib/ElementVariables.js
@@ -1,5 +1,7 @@
 import EventEmitter from 'events';
 
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
 export class ElementVariables extends EventEmitter {
   constructor(injector) {
     super();
@@ -27,8 +29,10 @@ export class ElementVariables extends EventEmitter {
         return [];
       });
 
-    this._variables[element.id] = variables;
+    const processVariables = variables.filter(({ scope }) => is(scope, 'bpmn:Process'));
 
-    return variables;
+    this._variables[element.id] = processVariables;
+
+    return processVariables;
   }
 }

--- a/lib/components/Input/InputEditor.jsx
+++ b/lib/components/Input/InputEditor.jsx
@@ -17,6 +17,8 @@ import theme from '../shared/CodeMirrorTheme';
 
 import { getAutocompletionExtensions } from '../../utils/autocompletion';
 
+import { SCOPES } from '../../TaskExecution';
+
 const fromPropAnnotation = Annotation.define();
 
 const autocompletionCompartment = new Compartment();
@@ -203,7 +205,11 @@ function getAllOutputVariables(allOutputs) {
           return;
         }
 
-        const { name, value } = /** @type {Object} */ (variable);
+        const { name, value, scope } = /** @type {Object} */ (variable);
+
+        if (scope !== SCOPES.PROCESS) {
+          return;
+        }
 
         allOutputVariables.push({ name, value, origin: elementId });
       });

--- a/test/components/Input/InputEditor.spec.js
+++ b/test/components/Input/InputEditor.spec.js
@@ -9,6 +9,8 @@ import InputEditor, { PLACEHOLDER_TEXT, INVALID_JSON_ERROR } from '../../../lib/
 
 import diagramXML from '../../fixtures/InputEditor.bpmn';
 
+import { SCOPES } from '../../../lib/TaskExecution';
+
 describe('InputEditor', function() {
 
   beforeEach(bootstrapModeler(diagramXML));
@@ -79,11 +81,13 @@ describe('InputEditor', function() {
           variables: {
             1: {
               name: 'foo',
-              value: '1'
+              value: '1',
+              scope: SCOPES.PROCESS
             },
             2: {
               name: 'bar',
-              value: '2'
+              value: '2',
+              scope: SCOPES.LOCAL
             },
           }
         },
@@ -91,7 +95,8 @@ describe('InputEditor', function() {
           variables: {
             3: {
               name: 'foo',
-              value: '3'
+              value: '3',
+              scope: SCOPES.PROCESS
             },
           }
         }
@@ -110,11 +115,10 @@ describe('InputEditor', function() {
       await waitFor(() => {
         const completionLabels = Array.from(container.querySelectorAll('.cm-completionLabel')).map(el => el.textContent);
 
-        expect(completionLabels.length).to.eql(3);
+        expect(completionLabels.length).to.eql(2);
 
-        expect(completionLabels[0]).to.eql('bar');
+        expect(completionLabels[0]).to.eql('foo');
         expect(completionLabels[1]).to.eql('foo');
-        expect(completionLabels[2]).to.eql('foo');
 
         const completionInfos = Array.from(container.querySelectorAll('.cm-completionInfo .info span')).map(el => el.textContent);
 


### PR DESCRIPTION
Closes https://github.com/camunda/task-testing/issues/58

### Proposed Changes

Make sure autocompletion only shows process variables:
- filter out local variables returned by the variables resolver,
- filter output variables by `scope`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
