### PR TITLE
fix: do not show link if onConfigureConnection not provided

### DIFF
--- a/lib/components/Output/Output.jsx
+++ b/lib/components/Output/Output.jsx
@@ -231,14 +231,14 @@ function ErrorBanner({
   description,
   actionLabel,
   actionUrl = '#',
-  onActionClick = () => {}
+  onActionClick
 }) {
   return (
     <div className="output__error">
       <div className="output__error--title">
         <span>{title}</span>
         {
-          actionLabel && <div className="output__error--action">
+          actionLabel && onActionClick && <div className="output__error--action">
             <Link href={ actionUrl } onClick={ () => onActionClick() }>
               { actionLabel }
             </Link>

--- a/test/components/Output/Output.spec.js
+++ b/test/components/Output/Output.spec.js
@@ -36,6 +36,45 @@ describe('Output', function() {
   });
 
 
+  describe('error banner', function() {
+
+    it('should render action link when onConfigureConnection is provided', async function() {
+
+      // when
+      const { queryByText } = renderWithProps({
+        isConnectionConfigured: false,
+        configureConnectionBannerTitle: 'Foo',
+        configureConnectionBannerDescription: 'Bar',
+        configureConnectionLabel: 'Baz',
+        onConfigureConnection: () => {}
+      });
+
+      // then
+      expect(queryByText(/Foo/i)).to.exist;
+      expect(queryByText(/Bar/i)).to.exist;
+      expect(queryByText(/Baz/i)).to.exist;
+    });
+
+
+    it('should not render action link when onConfigureConnection is not provided', async function() {
+
+      // when
+      const { queryByText } = renderWithProps({
+        isConnectionConfigured: false,
+        configureConnectionBannerTitle: 'Foo',
+        configureConnectionBannerDescription: 'Bar',
+        configureConnectionLabel: 'Baz'
+      });
+
+      // then
+      expect(queryByText(/Foo/i)).to.exist;
+      expect(queryByText(/Bar/i)).to.exist;
+      expect(queryByText(/Baz/i)).to.not.exist;
+    });
+
+  });
+
+
   describe('pickVariables', function() {
 
     it('should pick variables by scope', function() {
@@ -162,7 +201,7 @@ function renderWithProps(props) {
     configureConnectionBannerTitle = 'Configure Connection',
     configureConnectionBannerDescription = 'Please configure your connection settings.',
     configureConnectionLabel = 'Configure Connection',
-    onConfigureConnection = () => {},
+    onConfigureConnection,
     isTaskExecuting = false,
     output = {},
     onResetOutput = () => {},


### PR DESCRIPTION
### Proposed Changes

* `onConfigureConnection` controls visibility of both _Configure_ ⚙️ button _and_ link in error banner

<img width="1275" height="956" alt="image" src="https://github.com/user-attachments/assets/89393155-bd01-4277-b505-d0cb0dad1cb6" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
