### PR TITLE
chore: change to "completed" for test framing

### DIFF
--- a/lib/components/Output/Output.jsx
+++ b/lib/components/Output/Output.jsx
@@ -364,7 +364,7 @@ function ResultBanner({
       }
 
       if (output.success) {
-        return 'Test passed';
+        return 'Test completed';
       }
 
       if (output.terminated) {

--- a/lib/components/TaskTesting/TaskTesting.js
+++ b/lib/components/TaskTesting/TaskTesting.js
@@ -787,7 +787,7 @@ function HeaderStatusText({ isConnectionConfigured, configureConnectionBannerTit
     }
 
     if (output.success) {
-      return 'Passed';
+      return 'Completed';
     }
 
     if (output.terminated) {

--- a/test/components/Output/Output.spec.js
+++ b/test/components/Output/Output.spec.js
@@ -27,7 +27,7 @@ describe('Output', function() {
 
     // then
     expect(queryByText(/Result will appear here after you run the test/i)).to.exist;
-    expect(queryByText(/Test passed/i)).to.not.exist;
+    expect(queryByText(/Test completed/i)).to.not.exist;
     expect(queryByText(/Running test/i)).to.not.exist;
   });
 
@@ -58,7 +58,7 @@ describe('Output', function() {
     const { queryByText } = renderWithProps({ output });
 
     // then
-    expect(queryByText(/Test passed/i)).to.exist;
+    expect(queryByText(/Test completed/i)).to.exist;
   });
 
 


### PR DESCRIPTION

### Proposed Changes

This changes our framing from "test passed" to "test completed" - it is up to the user / their manual assessment to determine whether the completion is a success ("a pass").

<img width="641" height="224" alt="image" src="https://github.com/user-attachments/assets/d12795e4-9f8b-42ae-8453-0e6bcca7d49d" />

Related to [this discussion](https://camunda.slack.com/archives/GP70M0J6M/p1773211377950769).

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
