### PR TITLE
fix: ensure elements are clipped horizontally only

### DIFF
--- a/lib/style/style.scss
+++ b/lib/style/style.scss
@@ -168,8 +168,9 @@
       .task-testing__header-status-text {
         font-size: 14px;
         white-space: nowrap;
-        overflow: hidden;
+        overflow: clip visible;
         text-overflow: ellipsis;
+        min-width: 0;
       }
     }
 
@@ -356,8 +357,9 @@
       .output__banner-text {
         font-weight: 600;
         white-space: nowrap;
-        overflow: hidden;
+        overflow: clip visible;
         text-overflow: ellipsis;
+        min-width: 0;
       }
 
       .output__banner-timing {
@@ -423,8 +425,9 @@
         color: var(--color-text-secondary);
         white-space: nowrap;
         width: 30%;
-        overflow: hidden;
+        overflow: clip visible;
         text-overflow: ellipsis;
+        min-width: 0;
       }
 
       .output__banner-details-value {
@@ -632,16 +635,18 @@
       color: var(--color-text-secondary);
       white-space: nowrap;
       width: 30%;
-      overflow: hidden;
+      overflow: clip visible;
       text-overflow: ellipsis;
+      min-width: 0;
     }
 
     .execution-log__details-value {
       color: var(--color-text-primary);
       font-family: 'IBM Plex Mono', monospace;
       width: 70%;
-      overflow: hidden;
+      overflow: clip visible;
       text-overflow: ellipsis;
+      min-width: 0;
     }
 
     @container (max-width: 380px) {
@@ -763,8 +768,9 @@
 
     .execution-log__label {
       white-space: nowrap;
-      overflow: hidden;
+      overflow: clip visible;
       text-overflow: ellipsis;
+      min-width: 0;
     }
 
     .execution-log__label-row {
@@ -784,8 +790,9 @@
     .execution-log__secondary-label {
       color: var(--color-text-secondary);
       white-space: nowrap;
-      overflow: hidden;
+      overflow: clip visible;
       text-overflow: ellipsis;
+      min-width: 0;
       border-radius: 4px;
       background-color: var(--color-bg-light);
       padding: 2px 4px;


### PR DESCRIPTION
### Proposed Changes

Due to clipping in the UI various tests are cut off vertically - this PR adjusts that to only clip horizontally where we `text-overflow: ellipsis`.

#### Old

![capture OozcEq_optimized](https://github.com/user-attachments/assets/0aae199a-9756-46ef-9b5f-e1faad2f14b4)


### Fixed

![capture QOYjJd_optimized](https://github.com/user-attachments/assets/bd67f043-e495-4173-a725-577390f4ca78)


Try out via 

```
npx @bpmn-io/sr camunda/task-testing#clip-horizontally
```


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
