### PR TITLE
fix: use server-side timestamp for instance-started log entry

### DIFF
--- a/lib/ExecutionLog.js
+++ b/lib/ExecutionLog.js
@@ -482,6 +482,17 @@ export default class ExecutionLog {
       timestamp
     };
 
+    // Prefer server-side process instance startDate over the client-side timestamp
+    if (this._startInstanceResponse && result.processInstanceResponse?.success) {
+      const serverStartDate = toTimestamp(
+        result.processInstanceResponse.response?.items?.[0]?.startDate
+      );
+
+      if (serverStartDate) {
+        this._startInstanceResponse.timestamp = serverStartDate;
+      }
+    }
+
     this._updateEntries();
   }
 

--- a/test/ExecutionLog.spec.js
+++ b/test/ExecutionLog.spec.js
@@ -12,6 +12,7 @@ import {
   createGetProcessInstanceElementInstancesResponse,
   createGetProcessInstanceJobsResponse,
   createGetProcessInstanceMessageSubscriptionsResponse,
+  createGetProcessInstanceResponse,
   createGetProcessInstanceUserTasksResponse,
   createGetProcessInstanceVariablesResponse,
   createElementInstanceDetails,
@@ -20,6 +21,7 @@ import {
   createMessageSubscriptionDetails,
   createMockDate,
   createMockTimestamp,
+  createProcessInstanceDetails,
   createUserTaskDetails,
   ONE_SECOND_MS,
   DEFAULT_PROCESS_INSTANCE_KEY,
@@ -796,13 +798,19 @@ describe('ExecutionLog', function() {
 
         // when
         executionLog.setDeployResponse(createDeployResponse(), createMockTimestamp());
-        executionLog.setStartInstanceResponse(createStartInstanceResponse(), createMockTimestamp(ONE_SECOND_MS));
+        executionLog.setStartInstanceResponse(createStartInstanceResponse(), createMockTimestamp(ONE_SECOND_MS * 3));
         executionLog.setPolledResult(createPolledResult({
           jobsResponse: createGetProcessInstanceJobsResponse({
             response: { items: [ job ] }
           }),
           elementInstancesResponse: createGetProcessInstanceElementInstancesResponse({
             response: { items: [ elementInstance ] }
+          }),
+          processInstanceResponse: createGetProcessInstanceResponse({
+            response: {
+              items: [ createProcessInstanceDetails({ startDate: createMockDate(ONE_SECOND_MS) }) ],
+              page: { totalItems: 1 }
+            }
           })
         }), createMockTimestamp(ONE_SECOND_MS * 6));
 
@@ -814,6 +822,18 @@ describe('ExecutionLog', function() {
         for (let i = 1; i < timestamps.length; i++) {
           expect(timestamps[i]).to.be.at.least(timestamps[i - 1]);
         }
+
+        // Verify instance-started comes before element-instance entries
+        const types = entries.map(e => e.status || `${e.type}:${e.data?.state}`);
+
+        expect(types).to.deep.equal([
+          'deployed',
+          'instance-started',
+          'element-instance:ACTIVE',
+          'job:CREATED',
+          'job:COMPLETED',
+          'element-instance:COMPLETED'
+        ]);
       });
 
     });


### PR DESCRIPTION
Closes https://github.com/camunda/task-testing/issues/86

### Proposed Changes

The instance-started log entry used a [client-side](https://github.com/camunda/task-testing/blob/3c5a65c1b4036a1a0e7d30b88b779914e4b5a0f2/lib/ExecutionLog.js#L467) `Date.now()` timestamp captured when the HTTP response arrived, which could be later than the server-side element instance timestamps for fast tasks (e.g. script tasks), causing wrong entry ordering. Fixed by preferring the server-side process instance `startDate` from the polled result when available, falling back to the client timestamp before the first poll.

**Before:**
![Image](https://github.com/user-attachments/assets/203bacd8-b8a8-42d3-b49f-a3013c013c11)


**After:**
<img width="509" height="702" alt="image" src="https://github.com/user-attachments/assets/66cc974c-9cf7-4fcb-b3bc-fedf933ce918" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
