### PR TITLE
fix: position code editor button tooltip next to the button

### DIFF
--- a/lib/components/Input/InputEditor.jsx
+++ b/lib/components/Input/InputEditor.jsx
@@ -174,14 +174,16 @@ export default function InputEditor({
   }, [ editorView, value ]);
 
   return <div className={ classNames('code__editor', { 'code__editor--error': error }) }>
-    <Button
-      className="code__editor-clear-button"
-      renderIcon={ Erase }
-      iconDescription="Clear editor"
-      size="sm"
-      kind="ghost"
-      hasIconOnly
-      onClick={ onClear } />
+    <div className="code__editor-buttons">
+      <Button
+        renderIcon={ Erase }
+        iconDescription="Clear editor"
+        size="sm"
+        kind="ghost"
+        hasIconOnly
+        tooltipPosition="left"
+        onClick={ onClear } />
+    </div>
     <div className="code__editor-codemirror">
       <div ref={ ref } className="code__editor-codemirror-inner"></div>
     </div>

--- a/lib/components/Output/OutputEditor.jsx
+++ b/lib/components/Output/OutputEditor.jsx
@@ -66,16 +66,18 @@ export default function OutputEditor({ value }) {
   }, [ editorView, value ]);
 
   return <div className="code__editor">
-    <Button
-      className="code__editor-copy-button"
-      renderIcon={ Copy }
-      iconDescription="Copy to clipboard"
-      size="sm"
-      kind="ghost"
-      hasIconOnly
-      onClick={ () => {
-        navigator.clipboard.writeText(value);
-      } } />
+    <div className="code__editor-buttons">
+      <Button
+        renderIcon={ Copy }
+        iconDescription="Copy to clipboard"
+        size="sm"
+        kind="ghost"
+        hasIconOnly
+        tooltipPosition="left"
+        onClick={ () => {
+          navigator.clipboard.writeText(value);
+        } } />
+    </div>
     <div className="code__editor-codemirror">
       <div ref={ ref } className="code__editor-codemirror-inner"></div>
     </div>

--- a/lib/style/style.scss
+++ b/lib/style/style.scss
@@ -901,8 +901,7 @@
       margin-top: 5px;
     }
 
-    .code__editor-copy-button,
-    .code__editor-clear-button {
+    .code__editor-buttons {
       position: absolute;
       top: 5px;
       right: 5px;


### PR DESCRIPTION
### Proposed Changes

Render tooltip for a button inside of a code editor next to the button, instead of on the top of the editor.

Before:

<img width="434" height="119" alt="image" src="https://github.com/user-attachments/assets/85e9cc67-d5ce-454a-af7e-72977105567c" />

After:

<img width="539" height="123" alt="image" src="https://github.com/user-attachments/assets/232e9139-0168-4ccf-a8ea-81c5d9f2d15a" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
