### PR TITLE
fix: externalize react/jsx-runtime to support React 19

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,10 @@ module.exports = {
   },
   externals: {
     react: 'react',
+    'react/jsx-runtime': 'react/jsx-runtime',
+    'react/jsx-dev-runtime': 'react/jsx-dev-runtime',
     'react-dom': 'react-dom',
+    'react-dom/server': 'react-dom/server',
     '@carbon/react': '@carbon/react',
     '@carbon/icons-react': '@carbon/icons-react'
   },


### PR DESCRIPTION
## What

Mark `react/jsx-runtime`, `react/jsx-dev-runtime` and `react-dom/server` as webpack externals so they are no longer bundled into `dist/index.js`.

## Why

Closes #97.

The library declared `"react": "*"` as a peer dependency but in practice required React 18. Webpack bundled `react/jsx-runtime` (and `react-dom/server`, pulled in by `InputEditor.jsx` via `renderToStaticMarkup`). Those bundled copies access React internals such as `ReactCurrentOwner` / `ReactCurrentDispatcher` through `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`, which was removed in React 19. As a result the bundle crashed for consumers running React 19.

By externalizing these entry points, the consumer's installed React (18 or 19) provides them.

## Verification

- `npm run build:webpack` compiles successfully.
- The built `dist/index.js` no longer contains any `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` references (previously present).
- `react`, `react-dom`, `react/jsx-runtime` and `react-dom/server` are now emitted as ESM `import ... from` externals.