### PR TITLE
feat: support call activities in task testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes are documented here. We use [semantic versioning](http://sem
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support call activities in task testing ([#101](https://github.com/camunda/task-testing/pull/101))
+
+
 ## 5.1.0
 
 * `FIX`: don't bundle `react*` dependencies ([#98](https://github.com/camunda/task-testing/pull/98), [#97](https://github.com/camunda/task-testing/issues/97))

--- a/lib/ElementConfig.js
+++ b/lib/ElementConfig.js
@@ -14,14 +14,14 @@ import {
   computeMergedInput
 } from './utils/prefill';
 
+import { SUPPORTED_ELEMENT_TYPES } from './utils/element';
+
 export { DEFAULT_INPUT_CONFIG };
 
 export const DEFAULT_CONFIG = {
   input: {},
   output: {}
 };
-
-const SUPPORTED_ELEMENT_TYPES = [ 'bpmn:Task', 'bpmn:SubProcess' ];
 
 const DEFAULT_OUTPUT = undefined;
 

--- a/lib/ExecutionLog.js
+++ b/lib/ExecutionLog.js
@@ -17,6 +17,7 @@
  *   ExecutionLogMessageSubscriptionData,
  *   JobSearchResult,
  *   MessageSubscriptionResult,
+ *   ProcessInstanceResult,
  *   StartInstanceResponse,
  *   TaskExecutionFinishedResult,
  *   TaskExecutionPolledResult,
@@ -263,18 +264,27 @@ export function createUserTaskEntries(userTasks, fallbackTimestamp) {
  *
  * @param {ElementInstanceResult[]} instances
  * @param {number} fallbackTimestamp
+ * @param {ProcessInstanceResult[]} [childProcessInstances]
  *
  * @returns {ExecutionLogElementInstanceEntry[]}
  */
-export function createElementInstanceEntries(instances, fallbackTimestamp) {
+export function createElementInstanceEntries(instances, fallbackTimestamp, childProcessInstances) {
   const entries = [];
 
   for (const instance of instances) {
     const startedAt = toTimestamp(instance.startDate);
 
+    const childProcessInstance = childProcessInstances?.find(
+      ({ parentElementInstanceKey }) => parentElementInstanceKey === instance.elementInstanceKey
+    );
+
+    const overrides = childProcessInstance
+      ? { childProcessInstanceKey: childProcessInstance.processInstanceKey }
+      : {};
+
     entries.push({
       type: EXECUTION_LOG_ENTRY_TYPE.ELEMENT_INSTANCE,
-      data: pickElementInstanceData(instance, { state: 'ACTIVE' }),
+      data: pickElementInstanceData(instance, { ...overrides, state: 'ACTIVE' }),
       timestamp: startedAt || fallbackTimestamp
     });
 
@@ -286,7 +296,7 @@ export function createElementInstanceEntries(instances, fallbackTimestamp) {
 
     entries.push({
       type: EXECUTION_LOG_ENTRY_TYPE.ELEMENT_INSTANCE,
-      data: pickElementInstanceData(instance),
+      data: pickElementInstanceData(instance, overrides),
       timestamp: endedAt || fallbackTimestamp
     });
   }
@@ -829,11 +839,15 @@ export default class ExecutionLog {
       // timestamp, but are created when their element instance is entered
       let elementInstances = [];
 
+      const childProcessInstances = result.childProcessInstancesResponse?.success
+        ? result.childProcessInstancesResponse.response.items || []
+        : [];
+
       if (result.elementInstancesResponse?.success) {
         elementInstances = result.elementInstancesResponse.response.items || [];
 
         entries.push(
-          ...createElementInstanceEntries(elementInstances, timestamp)
+          ...createElementInstanceEntries(elementInstances, timestamp, childProcessInstances)
         );
       }
 

--- a/lib/TaskExecution.js
+++ b/lib/TaskExecution.js
@@ -256,6 +256,7 @@ export default class TaskExecution extends EventEmitter {
       }
 
       const responses = await Promise.all([
+        this._api.getChildProcessInstances(processInstanceKey),
         this._api.getProcessInstanceElementInstances(processInstanceKey),
         this._api.getProcessInstanceJobs(processInstanceKey),
         this._api.getProcessInstanceMessageSubscriptions(processInstanceKey),
@@ -278,6 +279,7 @@ export default class TaskExecution extends EventEmitter {
       }
 
       const [
+        childProcessInstancesResponse,
         elementInstancesResponse,
         jobsResponse,
         messageSubscriptionsResponse,
@@ -289,6 +291,7 @@ export default class TaskExecution extends EventEmitter {
       const polledResult = {
         elementId: element.id,
         processInstanceKey,
+        childProcessInstancesResponse,
         elementInstancesResponse,
         jobsResponse,
         messageSubscriptionsResponse,

--- a/lib/components/Output/Output.jsx
+++ b/lib/components/Output/Output.jsx
@@ -6,6 +6,7 @@
  * @import {
  *   ElementOutput,
  *   ExecutionLogEntry,
+ *   ExecutionLogElementInstanceEntry,
  *   ExecutionLogJobEntry,
  *   ExecutionLogUserTaskEntry,
  *   ExecutionLogMessageSubscriptionEntry,
@@ -39,6 +40,7 @@ import { PluginContext } from '../shared/plugins';
 import Tooltip from '../shared/Tooltip';
 import { SCOPES, pickVariables } from '../../utils/variables';
 import { EXECUTION_LOG_ENTRY_TYPE } from '../../ExecutionLog';
+import { getOperateUrl } from '../../utils/getOperateUrl';
 import { getTasklistUrl } from '../../utils/getTasklistUrl';
 
 /**
@@ -51,6 +53,7 @@ import { getTasklistUrl } from '../../utils/getTasklistUrl';
  * @param {Function} props.onResetOutput
  * @param {TaskExecutionState} props.taskExecutionState
  * @param {ExecutionLogEntry[]} props.executionLog
+ * @param {string} [props.operateBaseUrl]
  * @param {string} [props.tasklistBaseUrl]
  * @param {Object} [props.currentVariables]
  */
@@ -63,6 +66,7 @@ export default function Output({
   onResetOutput,
   taskExecutionState,
   executionLog,
+  operateBaseUrl,
   tasklistBaseUrl,
   currentVariables
 }) {
@@ -116,6 +120,7 @@ export default function Output({
         isTaskExecuting && <ExecutingBanner
           currentOperateUrl={ currentOperateUrl }
           entries={ executionLog }
+          operateBaseUrl={ operateBaseUrl }
           tasklistBaseUrl={ tasklistBaseUrl }
         />
       }
@@ -333,10 +338,11 @@ function EmptyState() {
  * @param {ExecutionLogEntry[]} [entries]
  * @param {string} [tasklistBaseUrl]
  * @param {string|null} [currentOperateUrl]
+ * @param {string} [operateBaseUrl]
  *
  * @returns {{ title: string, description: React.ReactNode, linkUrl: string|null, linkLabel: string } | null}
  */
-export function getWaitingContext(entries, tasklistBaseUrl, currentOperateUrl) {
+export function getWaitingContext(entries, tasklistBaseUrl, currentOperateUrl, operateBaseUrl) {
   if (!entries || !entries.length) {
     return null;
   }
@@ -420,11 +426,44 @@ export function getWaitingContext(entries, tasklistBaseUrl, currentOperateUrl) {
     };
   }
 
+  const terminalCallActivityKeys = new Set(
+    /** @type {ExecutionLogElementInstanceEntry[]} */ (entries
+      .filter(entry => entry.type === EXECUTION_LOG_ENTRY_TYPE.ELEMENT_INSTANCE
+        && entry.data.type === 'CALL_ACTIVITY'
+        && entry.data.state !== 'ACTIVE'))
+      .map(entry => entry.data.elementInstanceKey)
+  );
+
+  const activeCallActivity = /** @type {ExecutionLogElementInstanceEntry|undefined} */ (entries.find(
+    entry => entry.type === EXECUTION_LOG_ENTRY_TYPE.ELEMENT_INSTANCE
+      && entry.data.type === 'CALL_ACTIVITY'
+      && entry.data.state === 'ACTIVE'
+      && !terminalCallActivityKeys.has(entry.data.elementInstanceKey)
+  ));
+
+  if (activeCallActivity) {
+    const name = activeCallActivity.data.elementName || activeCallActivity.data.elementId;
+    const childProcessInstanceKey = activeCallActivity.data.childProcessInstanceKey;
+
+    const childProcessUrl = operateBaseUrl && childProcessInstanceKey
+      ? getOperateUrl(operateBaseUrl, childProcessInstanceKey)
+      : null;
+
+    return {
+      title: 'Waiting for called process completion',
+      description: name
+        ? <>The <span className="output__banner-tag">{ name }</span> call activity is waiting for the called process to complete.</>
+        : 'The call activity is waiting for the called process to complete.',
+      linkUrl: childProcessUrl,
+      linkLabel: 'Open called process in Operate'
+    };
+  }
+
   return null;
 }
 
-function ExecutingBanner({ currentOperateUrl, entries, tasklistBaseUrl }) {
-  const waitingContext = getWaitingContext(entries, tasklistBaseUrl, currentOperateUrl);
+function ExecutingBanner({ currentOperateUrl, entries, operateBaseUrl, tasklistBaseUrl }) {
+  const waitingContext = getWaitingContext(entries, tasklistBaseUrl, currentOperateUrl, operateBaseUrl);
 
   return (
     <div className="output__banner output__banner--executing">

--- a/lib/components/TaskTesting/TaskTesting.js
+++ b/lib/components/TaskTesting/TaskTesting.js
@@ -727,6 +727,7 @@ export default function TaskTesting({
                     onResetOutput={ handleResetOutput }
                     taskExecutionState={ taskExecutionState }
                     executionLog={ isTaskExecuting ? executionLog : (output?.executionLog || []) }
+                    operateBaseUrl={ operateBaseUrl }
                     tasklistBaseUrl={ tasklistBaseUrl }
                   />
                 )

--- a/lib/hooks/useSelectedElement.js
+++ b/lib/hooks/useSelectedElement.js
@@ -4,7 +4,7 @@ import {
   isAny
 } from 'bpmn-js/lib/util/ModelUtil';
 
-const SUPPORTED_ELEMENT_TYPES = [ 'bpmn:Task', 'bpmn:SubProcess' ];
+import { SUPPORTED_ELEMENT_TYPES } from '../utils/element';
 
 /**
  * @typedef {Object} SelectionInfo
@@ -13,18 +13,18 @@ const SUPPORTED_ELEMENT_TYPES = [ 'bpmn:Task', 'bpmn:SubProcess' ];
  */
 
 const SINGLE_TASK_SELECTION_REQUIRED = {
-  message: 'Select a task or subprocess to start testing.'
+  message: 'Select a task, subprocess, or call activity to start testing.'
 };
 
 const UNSUPPORTED_ELEMENT_SELECTED = {
   title: 'Unsupported element',
-  message: 'Task testing is only supported for tasks and subprocesses. Select one to start testing.'
+  message: 'Task testing is only supported for tasks, subprocesses, and call activities. Select one to start testing.'
 };
 
 /**
- * Get currently selected BPMN element, if it is a single supported element
- * (`bpmn:Task` or `bpmn:SubProcess`). If not, return null and a selection
- * info object with an optional title and a message indicating what to do.
+ * Get currently selected BPMN element, if it is a single supported element. If
+ * not, return null and a selection info object with an optional title and a
+ * message indicating what to do.
  *
  * @param {Object} injector
  *

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -79,6 +79,7 @@ export type ApiResponse<T> = {
 };
 
 export type DeployResponse = ApiResponse<DeploymentResult>;
+export type GetChildProcessInstancesResponse = ApiResponse<ProcessInstanceSearchQueryResult>;
 export type GetProcessInstanceResponse = ApiResponse<ProcessInstanceSearchQueryResult>;
 export type GetProcessInstanceElementInstancesResponse = ApiResponse<ElementInstanceSearchQueryResult>;
 export type GetProcessInstanceIncidentsResponse = ApiResponse<IncidentSearchQueryResult>;
@@ -89,6 +90,7 @@ export type GetProcessInstanceVariablesResponse = ApiResponse<VariableSearchQuer
 export type StartInstanceResponse = ApiResponse<CreateProcessInstanceResult>;
 
 export type TaskExecutionPolledResult = {
+  childProcessInstancesResponse: GetChildProcessInstancesResponse;
   elementId: string;
   elementInstancesResponse: GetProcessInstanceElementInstancesResponse;
   jobsResponse: GetProcessInstanceJobsResponse;
@@ -101,6 +103,7 @@ export type TaskExecutionPolledResult = {
 
 export type TaskExecutionApi = {
   deploy: () => Promise<DeployResponse>;
+  getChildProcessInstances: (processInstanceKey: string) => Promise<GetChildProcessInstancesResponse>;
   getProcessInstance: (processInstanceKey: string) => Promise<GetProcessInstanceResponse>;
   getProcessInstanceElementInstances: (processInstanceKey: string) => Promise<GetProcessInstanceElementInstancesResponse>;
   getProcessInstanceIncident: (processInstanceKey: string) => Promise<GetProcessInstanceIncidentsResponse>;
@@ -250,6 +253,7 @@ export type ExecutionLogElementInstanceData = {
   startDate?: string;
   endDate?: string;
   elementInstanceKey?: string;
+  childProcessInstanceKey?: string;
 };
 
 export type ExecutionLogMessageSubscriptionData = {

--- a/lib/utils/element.js
+++ b/lib/utils/element.js
@@ -5,6 +5,12 @@
 import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
 import { getLabel } from 'bpmn-js/lib/features/label-editing/LabelUtil';
 
+export const SUPPORTED_ELEMENT_TYPES = [
+  'bpmn:Task',
+  'bpmn:SubProcess',
+  'bpmn:CallActivity'
+];
+
 export function getName(element) {
   return getLabel(element);
 }

--- a/test/ElementConfig.spec.js
+++ b/test/ElementConfig.spec.js
@@ -130,6 +130,21 @@ describe('ElementConfig', function() {
     }));
 
 
+    it('should set input config for call activity', inject(function(elementRegistry) {
+
+      // given
+      const element = elementRegistry.get('CallActivity_1');
+
+      // when
+      elementConfig.setInputConfigForElement(element, '{"orderId": "baz"}');
+
+      // then
+      const inputConfigForElement = elementConfig.getInputConfigForElement(element);
+
+      expect(inputConfigForElement).to.eql('{"orderId": "baz"}');
+    }));
+
+
     it('should set output config for element', inject(function(elementRegistry) {
 
       // given

--- a/test/ExecutionLog.spec.js
+++ b/test/ExecutionLog.spec.js
@@ -19,6 +19,7 @@ import subprocessesXML from './fixtures/subprocesses.bpmn';
 import {
   createDeployResponse,
   createStartInstanceResponse,
+  createGetChildProcessInstancesResponse,
   createGetProcessInstanceElementInstancesResponse,
   createGetProcessInstanceJobsResponse,
   createGetProcessInstanceMessageSubscriptionsResponse,
@@ -567,6 +568,38 @@ describe('ExecutionLog', function() {
         // Second: completed entry
         expect(instanceEntries[1].data.state).to.equal('COMPLETED');
         expect(instanceEntries[1].timestamp).to.equal(new Date(endDate).getTime());
+      });
+
+
+      it('should attach child process instance key to call activity', function() {
+
+        // given
+        const instance = createElementInstanceDetails({
+          type: 'CALL_ACTIVITY',
+          state: 'ACTIVE',
+          elementInstanceKey: '1',
+          startDate: createMockDate(),
+          endDate: undefined
+        });
+
+        // when
+        executionLog.setPolledResult(createPolledResult({
+          childProcessInstancesResponse: createGetChildProcessInstancesResponse({
+            response: {
+              items: [ { processInstanceKey: '2', parentElementInstanceKey: '1' } ]
+            }
+          }),
+          elementInstancesResponse: createGetProcessInstanceElementInstancesResponse({
+            response: { items: [ instance ] }
+          })
+        }), createMockTimestamp());
+
+        // then
+        const entries = executionLog.getEntries();
+        const instanceEntries = entries.filter(e => e.type === EXECUTION_LOG_ENTRY_TYPE.ELEMENT_INSTANCE);
+
+        expect(instanceEntries).to.have.length(1);
+        expect(instanceEntries[0].data.childProcessInstanceKey).to.equal('2');
       });
 
     });
@@ -2055,6 +2088,7 @@ function createPolledResult(overrides = {}) {
   return {
     elementId: 'ServiceTask_1',
     processInstanceKey: DEFAULT_PROCESS_INSTANCE_KEY,
+    childProcessInstancesResponse: createGetChildProcessInstancesResponse(),
     elementInstancesResponse: createGetProcessInstanceElementInstancesResponse({
       response: { items: [], page: { totalItems: 0 } }
     }),

--- a/test/TaskExecution.spec.js
+++ b/test/TaskExecution.spec.js
@@ -10,6 +10,7 @@ import {
   createEmptyGetProcessInstanceMessageSubscriptionsResponse,
   createEmptyGetProcessInstanceResponse,
   createEmptyGetProcessInstanceUserTasksResponse,
+  createGetChildProcessInstancesResponse,
   createGetProcessInstanceElementInstancesResponse,
   createGetProcessInstanceIncidentResponse,
   createGetProcessInstanceJobsResponse,
@@ -66,6 +67,7 @@ describe('TaskExecution', function() {
   beforeEach(inject(function(injector) {
     api = {
       deploy: sinon.stub().resolves({ success: false, error: 'Not implemented' }),
+      getChildProcessInstances: sinon.stub().resolves(createGetChildProcessInstancesResponse()),
       getProcessInstance: sinon.stub().resolves({ success: false, error: 'Not implemented' }),
       getProcessInstanceElementInstances: sinon.stub().resolves({ success: false, error: 'Not implemented' }),
       getProcessInstanceIncident: sinon.stub().resolves({ success: false, error: 'Not implemented' }),

--- a/test/components/Output/Output.spec.js
+++ b/test/components/Output/Output.spec.js
@@ -702,6 +702,60 @@ describe('getWaitingContext', function() {
     expect(context.title).to.equal('Waiting for user task completion');
   });
 
+
+  it('should return context for active call activity', function() {
+
+    // given
+    const entries = [
+      createCallActivityEntry({
+        state: 'ACTIVE',
+        elementInstanceKey: '1',
+        childProcessInstanceKey: '2'
+      })
+    ];
+
+    // when
+    const context = getWaitingContext(entries, null, null, 'https://operate.example.com');
+
+    // then
+    expect(context).to.exist;
+    expect(context.title).to.equal('Waiting for called process completion');
+    expect(context.linkLabel).to.equal('Open called process in Operate');
+    expect(context.linkUrl).to.equal('https://operate.example.com/processes/2');
+  });
+
+
+  it('should return null for completed call activity', function() {
+
+    // given
+    const entries = [
+      createCallActivityEntry({ state: 'ACTIVE', elementInstanceKey: '1' }),
+      createCallActivityEntry({ state: 'COMPLETED', elementInstanceKey: '1' })
+    ];
+
+    // when
+    const context = getWaitingContext(entries, null, null, 'https://operate.example.com');
+
+    // then
+    expect(context).to.be.null;
+  });
+
+
+  it('should return context for active call activity without child process instance', function() {
+
+    // given
+    const entries = [
+      createCallActivityEntry({ state: 'ACTIVE', elementInstanceKey: '1' })
+    ];
+
+    // when
+    const context = getWaitingContext(entries, null, null, 'https://operate.example.com');
+
+    // then
+    expect(context).to.exist;
+    expect(context.linkUrl).to.be.null;
+  });
+
 });
 
 
@@ -755,6 +809,21 @@ function createUserTaskEntry(data, timestamp = 0) {
       state: 'CREATED',
       name: 'Foo',
       userTaskKey: '1',
+      ...data
+    },
+    timestamp
+  };
+}
+
+function createCallActivityEntry(data, timestamp = 0) {
+  return {
+    type: EXECUTION_LOG_ENTRY_TYPE.ELEMENT_INSTANCE,
+    data: {
+      type: 'CALL_ACTIVITY',
+      elementId: 'CallActivity_1',
+      elementName: 'Call activity',
+      state: 'ACTIVE',
+      elementInstanceKey: '1',
       ...data
     },
     timestamp

--- a/test/components/TaskTesting/TaskTesting.spec.js
+++ b/test/components/TaskTesting/TaskTesting.spec.js
@@ -59,7 +59,7 @@ describe('TaskTesting', function() {
     renderTaskTesting();
 
     // then
-    expect(screen.getByText('Select a task or subprocess to start testing.')).to.exist;
+    expect(screen.getByText('Select a task, subprocess, or call activity to start testing.')).to.exist;
   }));
 
 

--- a/test/components/TaskTesting/TaskTesting.spec.js
+++ b/test/components/TaskTesting/TaskTesting.spec.js
@@ -18,6 +18,7 @@ import { bootstrapModeler, inject, getModeler } from '../../helpers/modeler';
 import {
   createDeployResponse,
   createElementInstanceDetails,
+  createGetChildProcessInstancesResponse,
   createGetProcessInstanceElementInstancesResponse,
   createGetProcessInstanceIncidentResponse,
   createGetProcessInstanceJobsResponse,
@@ -504,6 +505,7 @@ describe('TaskTesting', function() {
 
       const api = {
         deploy: sinon.spy(() => Promise.resolve(createDeployResponse())),
+        getChildProcessInstances: sinon.spy(() => Promise.resolve(createGetChildProcessInstancesResponse())),
         getProcessInstance: sinon.spy(() => Promise.resolve(createGetProcessInstanceResponse({
           response: {
             items: [ createProcessInstanceDetails({ state: 'TERMINATED' }) ]
@@ -554,6 +556,7 @@ describe('TaskTesting', function() {
 
       const api = {
         deploy: sinon.spy(() => Promise.resolve(createDeployResponse())),
+        getChildProcessInstances: sinon.spy(() => Promise.resolve(createGetChildProcessInstancesResponse())),
         getProcessInstance: sinon.spy(() => Promise.resolve(createGetProcessInstanceResponse({
           response: {
             items: [ createProcessInstanceDetails({ state: 'ACTIVE', hasIncident: true }) ]

--- a/test/fixtures/ElementConfig.bpmn
+++ b/test/fixtures/ElementConfig.bpmn
@@ -81,6 +81,14 @@
     <bpmn:adHocSubProcess id="AdHocSubProcess_1">
       <bpmn:task id="AdHocChild_1" name="In ad-hoc subprocess" />
     </bpmn:adHocSubProcess>
+    <bpmn:callActivity id="CallActivity_1" name="Call child process">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="child-process" propagateAllChildVariables="true" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=orderId" target="childOrderId" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -109,6 +117,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="AdHocChild_1_di" bpmnElement="AdHocChild_1">
         <dc:Bounds x="270" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_1_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="510" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0d202t1_di" bpmnElement="Flow_0d202t1">
         <di:waypoint x="188" y="120" />

--- a/test/helpers/responses.js
+++ b/test/helpers/responses.js
@@ -253,6 +253,20 @@ export function createEmptyGetProcessInstanceResponse() {
   });
 }
 
+/**
+ * Creates a mock API response for getting child process instances with the given overrides.
+ *
+ * @param {Partial<ApiResponse<ProcessInstanceSearchQueryResult>>} overrides
+ *
+ * @returns {ApiResponse<ProcessInstanceSearchQueryResult>}
+ */
+export function createGetChildProcessInstancesResponse(overrides = {}) {
+  return createAPIResponse({
+    response: createSearchProcessInstancesSDKResponse({ items: [] }),
+    ...overrides
+  });
+}
+
 export const DEFAULT_VARIABLE_KEY = '1';
 export const DEFAULT_SCOPE_KEY = DEFAULT_PROCESS_INSTANCE_KEY;
 

--- a/test/hooks/useSelectedElement.spec.js
+++ b/test/hooks/useSelectedElement.spec.js
@@ -19,7 +19,7 @@ describe('useSelectedElement', function() {
     // then
     expect(selectedElement).to.be.null;
     expect(selectionInfo).to.deep.equal({
-      message: 'Select a task or subprocess to start testing.'
+      message: 'Select a task, subprocess, or call activity to start testing.'
     });
   }));
 
@@ -44,7 +44,7 @@ describe('useSelectedElement', function() {
     // then
     expect(selectedElement).to.be.null;
     expect(selectionInfo).to.deep.equal({
-      message: 'Select a task or subprocess to start testing.'
+      message: 'Select a task, subprocess, or call activity to start testing.'
     });
   }));
 
@@ -67,7 +67,7 @@ describe('useSelectedElement', function() {
     expect(selectedElement).to.be.null;
     expect(selectionInfo).to.deep.equal({
       title: 'Unsupported element',
-      message: 'Task testing is only supported for tasks and subprocesses. Select one to start testing.'
+      message: 'Task testing is only supported for tasks, subprocesses, and call activities. Select one to start testing.'
     });
   }));
 
@@ -98,6 +98,26 @@ describe('useSelectedElement', function() {
     const { result } = renderHook(() => useSelectedElement(injector));
 
     const element = elementRegistry.get('AdHocChild_1');
+
+    // when
+    act(() => {
+      selection.select(element);
+    });
+
+    const [ selectedElement, selectionInfo ] = result.current;
+
+    // then
+    expect(selectedElement).to.exist;
+    expect(selectionInfo).to.be.null;
+  }));
+
+
+  it('should return element if call activity is selected', inject(function(elementRegistry, injector, selection) {
+
+    // given
+    const { result } = renderHook(() => useSelectedElement(injector));
+
+    const element = elementRegistry.get('CallActivity_1');
 
     // when
     act(() => {


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6069

Added `bpmn:CallActivity` to the supported element types, so call activities can be selected and configured for testing.

Follow-up with desktop modeler API improvements to get the error for called activity - https://github.com/camunda/camunda-modeler/pull/6074

https://github.com/user-attachments/assets/e4cfeef4-6146-4f5b-af43-c4ecf1af5c0c

**Try it out**
Unfortunately, `bpmn-io/sr` doesn't work with this PR, so it requires manual npm linking to [camunda-modeler#call-activity-testing](https://github.com/camunda/camunda-modeler/pull/6074) to verify.

```bash
npx @bpmn-io/sr camunda/camunda-modeler#call-activity-testing -l camunda/task-testing#support-call-activity
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
