### PR TITLE
fix: do not prefill camunda variables

### DIFF
--- a/lib/ElementVariables.js
+++ b/lib/ElementVariables.js
@@ -42,8 +42,15 @@ export class ElementVariables extends EventEmitter {
         return [];
       });
 
-    return consumed.filter(({ origin = [] }) => {
-      return !(origin.length === 1 && origin[0].id === element.id);
+    return consumed.filter((variable) => {
+      const { origin = [] } = variable;
+
+      return !isEngineProvidedVariable(variable)
+        && !(origin.length === 1 && origin[0].id === element.id);
     });
   }
+}
+
+function isEngineProvidedVariable(variable) {
+  return variable.name === 'camunda';
 }

--- a/test/Prefill.spec.js
+++ b/test/Prefill.spec.js
@@ -38,6 +38,22 @@ describe('Prefill', function() {
     );
 
 
+    it('should not prefill engine-provided Camunda context',
+      inject(async function(elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('firstTask');
+
+        // when
+        const result = await elementConfig.getDefaultInputForElement(element);
+        const parsed = JSON.parse(result);
+
+        // then
+        expect(parsed).to.not.have.property('camunda');
+      })
+    );
+
+
     it('should only include requirements for the given element',
       inject(async function(elementRegistry) {
 
@@ -134,6 +150,24 @@ describe('Prefill', function() {
         // then
         expect(parsed).to.have.property('a', 42);
         expect(parsed).to.have.property('b', null);
+      })
+    );
+
+
+    it('should preserve user-provided Camunda context when merging',
+      inject(async function(elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('firstTask');
+
+        elementConfig.setInputConfigForElement(element, '{"camunda":{"custom":42}}');
+
+        // when
+        const merged = await elementConfig.getMergedInputConfigForElement(element);
+        const parsed = JSON.parse(merged);
+
+        // then
+        expect(parsed).to.have.nested.property('camunda.custom', 42);
       })
     );
 

--- a/test/fixtures/prefill.bpmn
+++ b/test/fixtures/prefill.bpmn
@@ -8,7 +8,7 @@
     </bpmn:extensionElements>
     <bpmn:scriptTask id="firstTask">
       <bpmn:extensionElements>
-        <zeebe:script expression="=a+b" resultVariable="firstResult" />
+        <zeebe:script expression="=a+b+camunda.vars.env.MY_CREDENTIAL.authentication.secretKey" resultVariable="firstResult" />
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:scriptTask>


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

Do not prefill Camunda-provided variables into the default input.

Related to https://github.com/camunda/camunda-modeler/pull/6099

https://github.com/user-attachments/assets/d441d878-328a-4e18-8f7d-e615ed7dc460

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->
